### PR TITLE
[Fix] style 沒有在 SSR 的時候就產生

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,6 +1,32 @@
 import Document, { Html, Head, Main, NextScript } from 'next/document'
+import { ServerStyleSheet } from 'styled-components'
 
 class MyDocument extends Document {
+  static async getInitialProps(ctx) {
+    const sheet = new ServerStyleSheet()
+    const originalRenderPage = ctx.renderPage
+
+    try {
+      ctx.renderPage = () =>
+        originalRenderPage({
+          enhanceApp: App => props => sheet.collectStyles(<App {...props} />),
+        })
+
+      const initialProps = await Document.getInitialProps(ctx)
+      return {
+        ...initialProps,
+        styles: (
+          <>
+            {initialProps.styles}
+            {sheet.getStyleElement()}
+          </>
+        ),
+      }
+    } finally {
+      sheet.seal()
+    }
+  }
+
   render() {
     return (
       <Html>


### PR DESCRIPTION
## Summary

- 修正 style 沒有在 SSR 的時候產生，造成會先看到第一屏未 style 的畫面，依照 [next.js 的建議](https://github.com/vercel/next.js/tree/master/examples/with-styled-components/pages)修正