### PR TITLE
[Fix][project] 順序重複 + 阻擋相同 id

### DIFF
--- a/components/Admin/Illustration/UploadModal.js
+++ b/components/Admin/Illustration/UploadModal.js
@@ -54,17 +54,11 @@ function UploadModal({ closeModal }) {
   }
 
   const queryClient = useQueryClient()
-  const { data, queryKey } = useIllustration()
+  const { queryKey } = useIllustration()
   const { submit, isLoading } = useCreateIllustration()
 
   function onSubmit() {
-    const submitData = images.map((image, index) => {
-      const currentOrder = index + 1
-      return {
-        ...image,
-        order: data[0] ? data[0].order + currentOrder : currentOrder,
-      }
-    })
+    const submitData = images
     submit(submitData, {
       onSuccess: newData => {
         closeModal()

--- a/components/Admin/Project/New.js
+++ b/components/Admin/Project/New.js
@@ -12,21 +12,18 @@ function New() {
   }
 
   const queryClient = useQueryClient()
-  const { data, queryKey } = useProjects()
+  const { queryKey } = useProjects()
   const { submit, isLoading } = useCreateProject()
   function onSubmit(values) {
-    submit(
-      { order: data.length + 1, ...values },
-      {
-        onSuccess: () => {
-          queryClient.setQueryData(queryKey, oldData => [values, ...oldData])
-          onClose()
-        },
-        onError: error => {
-          Modal.error({ title: '錯誤', content: error.message || '發生錯誤' })
-        },
-      }
-    )
+    submit(values, {
+      onSuccess: () => {
+        queryClient.setQueryData(queryKey, oldData => [values, ...oldData])
+        onClose()
+      },
+      onError: error => {
+        Modal.error({ title: '錯誤', content: error.message || '發生錯誤' })
+      },
+    })
   }
 
   return (

--- a/components/Admin/Project/New.js
+++ b/components/Admin/Project/New.js
@@ -21,7 +21,11 @@ function New() {
         onClose()
       },
       onError: error => {
-        Modal.error({ title: '錯誤', content: error.message || '發生錯誤' })
+        Modal.error({
+          centered: true,
+          title: '錯誤',
+          content: error.message || '發生錯誤',
+        })
       },
     })
   }

--- a/components/api/project/useCreateProject.js
+++ b/components/api/project/useCreateProject.js
@@ -6,7 +6,7 @@ function createProjectAPI(data) {
     .post('/api/projects', data)
     .then(response => response.data)
     .catch(error => {
-      if (error.response) throw new Error(error.response.data.message)
+      if (error.response) throw new Error(error.response.data)
       throw error
     })
 }

--- a/pages/api/projects/index.js
+++ b/pages/api/projects/index.js
@@ -17,7 +17,13 @@ async function handler(req, res) {
       }
     }
     if (req.method === 'POST') {
-      const data = req.body
+      const snapshot = await db.collection('projects').get()
+      const startOrder =
+        snapshot?.docs?.length > 0
+          ? Math.max(...snapshot.docs.map(doc => doc.data().order)) + 1
+          : 1
+
+      const data = { ...req.body, order: startOrder + 1 }
       await db.collection('projects').doc(data.id).set(data)
       res.status(201).json('succeed')
     }

--- a/pages/api/projects/index.js
+++ b/pages/api/projects/index.js
@@ -17,14 +17,22 @@ async function handler(req, res) {
       }
     }
     if (req.method === 'POST') {
+      const data = req.body
       const snapshot = await db.collection('projects').get()
+
+      if (snapshot.docs.some(doc => data.id === doc.data().id)) {
+        return res.status(400).json('網址重複，請重新命名')
+      }
+
       const startOrder =
-        snapshot?.docs?.length > 0
+        snapshot.docs.length > 0
           ? Math.max(...snapshot.docs.map(doc => doc.data().order)) + 1
           : 1
 
-      const data = { ...req.body, order: startOrder + 1 }
-      await db.collection('projects').doc(data.id).set(data)
+      await db
+        .collection('projects')
+        .doc(data.id)
+        .set({ ...data, order: startOrder + 1 })
       res.status(201).json('succeed')
     }
   } catch (error) {


### PR DESCRIPTION
### Summary
- 原本 project 使用 `data.length` 換算 order 會造成以下狀況專案 order 相同
    - 雙開視窗，同時在不同視窗建立不同專案
    - 先刪除專案後又新增一個新專案
- illustration 雖然有用當下資料的最大 order 去換算，一樣雙開還是有風險，所以一起改成後端拿 db 資料產生
- 優化避免建立相同 id 專案